### PR TITLE
Build Oven

### DIFF
--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -20,12 +20,13 @@ RUN cd /opt/overte-build \
     && cd ./build \
     && export OVERTE_USE_SYSTEM_QT=1 \
     && export RELEASE_TYPE=PRODUCTION \
-    && cmake -DSERVER_ONLY=1 -DOVERTE_CPU_ARCHITECTURE=-msse3 ..
+    && cmake -DSERVER_ONLY=1 -DBUILD_TOOLS=1 -DOVERTE_CPU_ARCHITECTURE=-msse3 ..
 
 # put number after -j to limit cores.
 RUN cd /opt/overte-build/build \
     && make -j domain-server \
     && make -j assignment-client \
+    && make -j oven  # needed for baking
 
 RUN VCPKG_PATH=$(python3 /opt/overte-build/prebuild.py --get-vcpkg-path --build-root . --quiet) && \
     echo "VCPKG Path: $VCPKG_PATH" && \
@@ -36,4 +37,5 @@ RUN mv /opt/overte-build/build/libraries /opt/overte/libraries \
     && mv /opt/overte-build/build/assignment-client/assignment-client /opt/overte/assignment-client \
     && mv /opt/overte-build/build/assignment-client/plugins /opt/overte/plugins \
     && mv /opt/overte-build/build/domain-server/domain-server /opt/overte/domain-server \
-    && mv /opt/overte-build/domain-server/resources /opt/overte/resources
+    && mv /opt/overte-build/domain-server/resources /opt/overte/resources \
+    && mv /opt/overte-build/build/tools/oven/oven /opt/overte/oven

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -8,7 +8,7 @@ RUN mkdir /opt/overte-build \
     && mkdir /opt/overte
 
 # Install dependencies
-RUN apt update && apt install -y python3-full zip tzdata curl ninja-build git cmake g++ npm libssl-dev python3-distutils python3-distro mesa-common-dev libgl1-mesa-dev \
+RUN apt update && apt install -y python3-full zip tzdata curl ninja-build git cmake g++ libssl-dev python3-distutils python3-distro mesa-common-dev libgl1-mesa-dev \
     libqt5websockets5-dev qtscript5-dev qtdeclarative5-dev qtmultimedia5-dev libqt5webchannel5-dev qtwebengine5-dev libqt5xmlpatterns5-dev
 
 # Fetch repository
@@ -24,7 +24,8 @@ RUN cd /opt/overte-build \
 
 # put number after -j to limit cores.
 RUN cd /opt/overte-build/build \
-    && make -j 
+    && make -j domain-server \
+    && make -j assignment-client \
 
 RUN VCPKG_PATH=$(python3 /opt/overte-build/prebuild.py --get-vcpkg-path --build-root . --quiet) && \
     echo "VCPKG Path: $VCPKG_PATH" && \


### PR DESCRIPTION
This PR enables Oven, which is used by the asset server to bake assets. The server-console is disabled, since it's a GUI tool that isn't used on headless servers.

